### PR TITLE
Add ai_project option

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,9 +8,11 @@
     "author_name": "Adam Amer",
     "author_email": "adam@example.com",
     "github_username": "adamamer20",
-    "python_version": "3.12",
     "initial_version": "0.1.0",
-    "ruff_version": "v0.11.13",
+    "ai_project": [
+        "n",
+        "y"
+    ],
     "license": [
         "MIT",
         "Apache-2.0",

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -198,7 +198,6 @@ def test_custom_parameters():
                 "project_name=Custom Project",
                 "author_name=Test Author",
                 "author_email=test@example.com",
-                "python_version=3.11",
                 f"--output-dir={temp_dir}",
             ],
             check=True,
@@ -214,6 +213,31 @@ def test_custom_parameters():
         assert "custom-project" in content
         assert "Test Author" in content
         assert "test@example.com" in content
+
+
+def test_ai_project_optional_dependencies():
+    """Ensure AI project extras are included when enabled."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        run_subprocess(
+            [
+                "cookiecutter",
+                str(Path(__file__).parent.parent),
+                "--no-input",
+                "ai_project=y",
+                f"--output-dir={temp_dir}",
+            ],
+            check=True,
+        )
+
+        pyproject_path = (
+            Path(temp_dir)
+            / "my-amazing-library"
+            / "pyproject.toml"
+        )
+        content = pyproject_path.read_text()
+        assert "[project.optional-dependencies]" in content
+        assert "polars" in content
+        assert "torch" in content
 
 
 if __name__ == "__main__":

--- a/{{cookiecutter.repo_name}}/.cruft.json
+++ b/{{cookiecutter.repo_name}}/.cruft.json
@@ -10,9 +10,8 @@
             "author_name": "{{ cookiecutter.author_name }}",
             "author_email": "{{ cookiecutter.author_email }}",
             "github_username": "{{ cookiecutter.github_username }}",
-            "python_version": "{{ cookiecutter.python_version }}",
             "initial_version": "{{ cookiecutter.initial_version }}",
-            "ruff_version": "{{ cookiecutter.ruff_version }}",
+            "ai_project": "{{ cookiecutter.ai_project }}",
             "license": "{{ cookiecutter.license }}",
             "use_docker": "{{ cookiecutter.use_docker }}",
             "project_short_description": "{{ cookiecutter.project_short_description }}"

--- a/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.repo_name}}/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ ci:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "{{ cookiecutter.ruff_version }}"
+    rev: "v0.11.13"
     hooks:
       - id: ruff
         args: [--fix]

--- a/{{cookiecutter.repo_name}}/Dockerfile
+++ b/{{cookiecutter.repo_name}}/Dockerfile
@@ -1,7 +1,7 @@
 {%- if cookiecutter.use_docker == 'y' %}
 # Multi-stage build for {{ cookiecutter.project_name }}
 # Stage 1: Builder - Install dependencies and build wheel
-FROM python:{{ cookiecutter.python_version }}-slim as builder
+FROM python:3.12-slim as builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
@@ -34,7 +34,7 @@ COPY README.md LICENSE ./
 RUN uv build --wheel
 
 # Stage 2: Runtime - Minimal production image
-FROM python:{{ cookiecutter.python_version }}-slim as runtime
+FROM python:3.12-slim as runtime
 
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "cruft>=2.15.0",
 ]
 
+{% if cookiecutter.ai_project == 'y' %}
 [project.optional-dependencies]
 data = [
     "polars>=0.20.0",
@@ -52,6 +53,7 @@ ml = [
     "torch>=2.0.0",
     "transformers>=4.30.0",
 ]
+{% endif %}
 
 [project.urls]
 Homepage = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}"


### PR DESCRIPTION
## Summary
- add `ai_project` option to include ML/data extras
- remove ruff and python version options
- update Dockerfile, pre-commit config and cruft context
- support optional extras in `pyproject.toml`
- update tests for new behaviour and add AI option test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ec5cb34c832f899d7a59abc007a9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to include AI-related optional dependencies (such as polars, torch, transformers, numpy, and matplotlib) when generating a new project.
- **Bug Fixes**
  - Fixed Python and Ruff version references by switching to fixed versions in Docker and pre-commit configurations.
- **Tests**
  - Added a test to verify the inclusion of AI-related optional dependencies when the AI project option is enabled.
- **Chores**
  - Updated configuration files to remove unused version variables and add the AI project option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->